### PR TITLE
Fix breakpoints map comma

### DIFF
--- a/src/styles/abstracts/_breakpoints.scss
+++ b/src/styles/abstracts/_breakpoints.scss
@@ -11,7 +11,7 @@ $breakpoints: (
 	// 319 px
 	tablet: 743px,
 	// 743 px
-	desktop: 1200px // 1200 px,,,,,,,,,,,,
+        desktop: 1200px // 1200 px,
 ) !default;
 
 /* 2. Syntactic sugar → funkcja bp() */


### PR DESCRIPTION
## Summary
- remove stray commas in `desktop` breakpoint entry for `_breakpoints.scss`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f57029228832294ee9c4cd01bc283