### PR TITLE
Implement vite-imagetools and add responsive hero image

### DIFF
--- a/src/components/index-hero.kit
+++ b/src/components/index-hero.kit
@@ -36,13 +36,23 @@
 			</a>
 		</div>
 
-		<img
-			src="/src/assets/images/index-hero-man.jpg"
-			alt="Zamyślony mężczyzna siedzący na łóżku"
-			width="576"
-			height="975"
-			loading="lazy"
-			class="hero__image"
-		/>
-	</div>
+                <picture class="hero__image-wrapper">
+                        <source
+                                type="image/avif"
+                                srcset="/src/assets/images/index-hero-man.jpg?imagetools&w=576;768;1024&format=avif&as=srcset"
+                        />
+                        <source
+                                type="image/webp"
+                                srcset="/src/assets/images/index-hero-man.jpg?imagetools&w=576;768;1024&format=webp&as=srcset"
+                        />
+                        <img
+                                src="/src/assets/images/index-hero-man.jpg?imagetools&w=576"
+                                alt="Zamyślony mężczyzna siedzący na łóżku"
+                                width="576"
+                                height="975"
+                                loading="lazy"
+                                class="hero__image"
+                        />
+                </picture>
+        </div>
 </section>

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,6 +20,7 @@ import mkcert from 'vite-plugin-mkcert';
 import Inspect from 'vite-plugin-inspect';
 import FullReload from 'vite-plugin-full-reload';
 import { ViteImageOptimizer } from 'vite-plugin-image-optimizer';
+import { imagetools } from 'vite-imagetools';
 
 // import PluginCritical from 'rollup-plugin-critical';
 /* — helpery — */
@@ -78,8 +79,9 @@ export default defineConfig(({ mode }) => {
 			},
 		},
 		plugins: [
-			Inspect(),
-			clean({ targets: ['./dist'] }),
+                        Inspect(),
+                        imagetools(),
+                        clean({ targets: ['./dist'] }),
 			FaviconsInject(
 				resolve(__dirname, 'public/logo.svg'),
 				{


### PR DESCRIPTION
## Summary
- enable `vite-imagetools` plugin
- use plugin to output responsive sources for hero image

## Testing
- `npm install` *(fails: Protocol "https:" not supported)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5f0031e08322856411c174b841ef