### PR TITLE
Configure imagetools and update hero image

### DIFF
--- a/src/components/index-hero.kit
+++ b/src/components/index-hero.kit
@@ -39,14 +39,14 @@
                 <picture class="hero__image-wrapper">
                         <source
                                 type="image/avif"
-                                srcset="/src/assets/images/index-hero-man.jpg?imagetools&w=576;768;1024&format=avif&as=srcset"
+                                srcset="@img/index-hero-man.jpg?imagetools&w=576;768;1024&format=avif&as=srcset"
                         />
                         <source
                                 type="image/webp"
-                                srcset="/src/assets/images/index-hero-man.jpg?imagetools&w=576;768;1024&format=webp&as=srcset"
+                                srcset="@img/index-hero-man.jpg?imagetools&w=576;768;1024&format=webp&as=srcset"
                         />
                         <img
-                                src="/src/assets/images/index-hero-man.jpg?imagetools&w=576"
+                                src="@img/index-hero-man.jpg?imagetools&w=576"
                                 alt="Zamyślony mężczyzna siedzący na łóżku"
                                 width="576"
                                 height="975"

--- a/vite.config.js
+++ b/vite.config.js
@@ -78,9 +78,16 @@ export default defineConfig(({ mode }) => {
 				'@img': resolve(__dirname, 'src/assets/images'),
 			},
 		},
-		plugins: [
+                plugins: [
                         Inspect(),
-                        imagetools(),
+                        imagetools({
+                                defaultDirectives: (url) => {
+                                        if (!url.searchParams.has('format') && /(png|jpe?g)$/.test(url.pathname)) {
+                                                return new URLSearchParams({ format: 'webp;avif' });
+                                        }
+                                        return new URLSearchParams();
+                                },
+                        }),
                         clean({ targets: ['./dist'] }),
 			FaviconsInject(
 				resolve(__dirname, 'public/logo.svg'),


### PR DESCRIPTION
## Summary
- configure imagetools to automatically output `webp`/`avif` when jpg/png images are processed
- use image alias inside the hero component

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f639f7a008322985f0e702a16dfdb