### PR TITLE
Fix hero picture breakpoints and ignore public images

### DIFF
--- a/src/components/index-hero.kit
+++ b/src/components/index-hero.kit
@@ -39,17 +39,17 @@
                 <picture class="hero__image-wrapper">
                         <source
                                 type="image/avif"
-                                srcset="/src/assets/images/index-hero-man.jpg?imagetools&w=576;768;1024&format=avif&as=srcset"
+                                srcset="/src/assets/images/index-hero-man.jpg?imagetools&w=319;743;1200&format=avif&as=srcset"
                         />
                         <source
                                 type="image/webp"
-                                srcset="/src/assets/images/index-hero-man.jpg?imagetools&w=576;768;1024&format=webp&as=srcset"
+                                srcset="/src/assets/images/index-hero-man.jpg?imagetools&w=319;743;1200&format=webp&as=srcset"
                         />
                         <img
-                                src="/src/assets/images/index-hero-man.jpg?imagetools&w=576"
+                                src="/src/assets/images/index-hero-man.jpg?imagetools&w=319"
                                 alt="Zamyślony mężczyzna siedzący na łóżku"
-                                width="576"
-                                height="975"
+                                width="319"
+                                height="540"
                                 loading="lazy"
                                 class="hero__image"
                         />

--- a/vite.config.js
+++ b/vite.config.js
@@ -53,7 +53,6 @@ const imageConvertPlugin = () => ({
         async buildStart() {
                 const files = await fg([
                         'src/assets/images/**/*.{jpg,png}',
-                        'public/**/*.{jpg,png}',
                 ]);
                 await Promise.all(
                         files.map(async (file) => {


### PR DESCRIPTION
## Summary
- do not convert `public/` images in custom `imageConvertPlugin`
- adapt `<picture>` for hero image to 319/743/1200 widths

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f6d11986083228f797c3dab0123fb